### PR TITLE
feat(ir): Implement IR-LL data structures

### DIFF
--- a/crates/naldom-ir/src/lib.rs
+++ b/crates/naldom-ir/src/lib.rs
@@ -124,20 +124,14 @@ pub enum LLType {
 #[derive(Debug, Clone, PartialEq)]
 pub enum LLInstruction {
     /// Allocates space on the stack. Returns a pointer to the allocated space.
-    Alloc {
-        dest: Register,
-        ty: LLType,
-    },
+    Alloc { dest: Register, ty: LLType },
     /// Loads a value from a memory address (pointer).
     Load {
         dest: Register,
         source_ptr: Register,
     },
     /// Stores a value to a memory address (pointer).
-    Store {
-        value: LLValue,
-        dest_ptr: Register,
-    },
+    Store { value: LLValue, dest_ptr: Register },
     /// Calls a function.
     Call {
         dest: Option<Register>, // `None` for void functions

--- a/crates/naldom-ir/src/lib.rs
+++ b/crates/naldom-ir/src/lib.rs
@@ -80,3 +80,93 @@ pub enum HLValue {
     String(String),
     // We can add more types like Float, Bool, etc. later.
 }
+
+/// Low-Level Intermediate Representation (IR-LL).
+///
+/// This is a much lower-level, explicit representation, very close to LLVM IR or assembly.
+/// It operates on concepts like virtual registers, basic blocks, and simple, atomic instructions.
+/// This representation is the final step before generating target-specific code (like LLVM IR).
+#[derive(Debug, Clone, PartialEq)]
+pub struct LLProgram {
+    pub functions: Vec<LLFunction>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct LLFunction {
+    pub name: String,
+    pub parameters: Vec<(LLType, Register)>,
+    pub return_type: LLType,
+    pub basic_blocks: Vec<BasicBlock>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BasicBlock {
+    pub id: usize,
+    pub instructions: Vec<LLInstruction>,
+    pub terminator: Terminator,
+}
+
+/// A virtual register, representing a temporary value. e.g., `%0`, `%1`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Register(pub u32);
+
+/// Represents the primitive types in our low-level language.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LLType {
+    Void,
+    I32,
+    I64,
+    F64,
+    Pointer(Box<LLType>),
+}
+
+/// Represents a single, atomic operation.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LLInstruction {
+    /// Allocates space on the stack. Returns a pointer to the allocated space.
+    Alloc {
+        dest: Register,
+        ty: LLType,
+    },
+    /// Loads a value from a memory address (pointer).
+    Load {
+        dest: Register,
+        source_ptr: Register,
+    },
+    /// Stores a value to a memory address (pointer).
+    Store {
+        value: LLValue,
+        dest_ptr: Register,
+    },
+    /// Calls a function.
+    Call {
+        dest: Option<Register>, // `None` for void functions
+        function_name: String,
+        arguments: Vec<LLValue>,
+    },
+    // We will add more instructions like Add, Sub, ICmp later.
+}
+
+/// Represents an instruction that terminates a basic block, controlling flow.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Terminator {
+    /// Returns from a function.
+    Return(Option<LLValue>),
+    // We will add branching instructions like `Br` and `CondBr` later.
+}
+
+/// Represents a value that can be used as an operand in an instruction.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LLValue {
+    Register(Register),
+    Constant(LLConstant),
+}
+
+/// Represents a constant literal value.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LLConstant {
+    I32(i32),
+    I64(i64),
+    F64(f64),
+    // We can add string literals, etc., later.
+}


### PR DESCRIPTION
Closes #1

This pull request implements the initial data structures for the Low-Level Intermediate Representation (IR-LL) as defined in Issue #1. This is a foundational step for Phase 2, moving us towards a native compilation backend.

### Key Changes

- **Added to `crates/naldom-ir/src/lib.rs`:**
  - `LLProgram`, `LLFunction`, and `BasicBlock` to define the overall program structure.
  - `Register` struct for representing virtual registers.
  - `LLType` enum for primitive types (`I64`, `F64`, `Pointer`, etc.).
  - `LLInstruction` enum for atomic operations like `Alloc`, `Load`, `Store`, and `Call`.
  - `Terminator` enum for control flow instructions, starting with `Return`.
  - `LLValue` and `LLConstant` to represent instruction operands.

### Impact

With these structures in place, we now have a clearly defined target for our next compilation stage. The design is closely aligned with LLVM IR concepts, which will simplify the implementation of the LLVM codegen backend.

### Next Steps

The next task is to implement the lowering pass that converts `IR-HL` into this new `IR-LL`.

---

#### Pull Request Checklist

- [x] I have read the `CONTRIBUTING.md` document.
- [x] My code follows the project's coding style guidelines (e.g., `cargo fmt` for Rust).
- [ ] I have added/updated tests for my changes. *(N/A for this change, as it's only data structures)*
- [x] All existing tests pass.
- [x] My commit message follows the Conventional Commits specification.