### PR TITLE
feat(compiler): Integrate inkwell and set up LLVM backend

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,3 +1,5 @@
+# .github/workflows/rust-ci.yml
+
 name: Rust CI
 
 on:
@@ -14,10 +16,16 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Install LLVM 17
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: "17"
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/crates/naldom-core/Cargo.toml
+++ b/crates/naldom-core/Cargo.toml
@@ -9,6 +9,7 @@ description = "Core compiler components for Naldom: NLD Parser, IntentGraph, Sem
 
 [dependencies]
 naldom-ir = { path = "../naldom-ir" }
-reqwest = { version = "0.12.5", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+reqwest = { version = "0.12.5", features = ["blocking", "json"] }
+inkwell = { version = "0.6.0", default-features = false, features = ["llvm17-0", "target-x86", "target-webassembly"] }

--- a/crates/naldom-core/src/codegen_llvm.rs
+++ b/crates/naldom-core/src/codegen_llvm.rs
@@ -1,0 +1,29 @@
+// crates/naldom-core/src/codegen_llvm.rs
+
+use inkwell::context::Context;
+use naldom_ir::LLProgram;
+
+/// The context for LLVM code generation.
+/// This struct will hold the LLVM context, builder, module, etc.
+#[allow(dead_code)] // We allow dead code for now as this is a placeholder struct.
+pub struct CodeGenContext<'ctx> {
+    context: &'ctx Context,
+}
+
+/// The main entry point for generating LLVM IR from an LLProgram.
+///
+/// For now, this function is a "smoke test". It simply creates an LLVM context
+/// and an empty module to verify that the `inkwell` library and the system's
+/// LLVM installation are linked and working correctly.
+pub fn generate_llvm_ir(_ll_program: &LLProgram) -> Result<String, String> {
+    // Create the top-level LLVM context.
+    let context = Context::create();
+    let _codegen_context = CodeGenContext { context: &context };
+
+    // Create a module to hold our code.
+    let module = context.create_module("naldom_module");
+
+    // For now, we just verify that the module can be created and converted to a string.
+    // This proves that the core LLVM components are working.
+    Ok(module.print_to_string().to_string())
+}

--- a/crates/naldom-core/src/lib.rs
+++ b/crates/naldom-core/src/lib.rs
@@ -2,6 +2,7 @@
 
 //! The core compiler components for the Naldom language.
 
+pub mod codegen_llvm;
 pub mod codegen_python;
 pub mod llm_inference;
 pub mod lowering;


### PR DESCRIPTION
Closes #4

This PR integrates the `inkwell` library, which is the foundation for our LLVM-based native compilation backend.

### Key Changes
- The `inkwell` crate (v0.6.0 with `llvm17-0` feature) has been added as a dependency to `naldom-core`.
- A new `codegen_llvm.rs` module has been created to house all future LLVM generation logic.
- A minimal "smoke test" implementation of `generate_llvm_ir` is included. It creates an LLVM context and module to verify that the dependency is correctly linked.
- The placeholder `CodeGenContext` struct has been annotated with `#[allow(dead_code)]` to pass our strict CI checks.

### Important Note for Contributors
Building this branch and future ones now requires **LLVM 17** to be installed on the system. Instructions will be added to `CONTRIBUTING.md` in a future PR.

---
#### Pull Request Checklist
- [x] I have read the `CONTRIBUTING.md` document.
- [x] My code follows the project's coding style guidelines (`cargo fmt`).
- [ ] I have added/updated tests for my changes. *(N/A for this dependency setup)*
- [x] All existing tests pass.
- [x] My commit message follows the Conventional Commits specification.