### PR TITLE
feat(runtime): Create native C runtime and fix codegen signatures

### DIFF
--- a/runtime/native/naldom_runtime.c
+++ b/runtime/native/naldom_runtime.c
@@ -1,0 +1,77 @@
+// runtime/native/naldom_runtime.c
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <time.h>
+
+// A simple struct to act as a "fat pointer" for our arrays,
+// containing both the data and its size.
+// This is a common pattern when interfacing with languages that don't
+// have built-in array sizes.
+typedef struct {
+    double* data;
+    int64_t size;
+} NaldomArray;
+
+// This function is called from our compiled code.
+// It must be marked `extern "C"` if we were in C++, but in C it's the default.
+NaldomArray* create_random_array(int64_t size) {
+    printf("Runtime: Creating an array of %lld random numbers...\n", size);
+
+    // Seed the random number generator
+    srand(time(NULL));
+
+    // Allocate memory for our array struct
+    NaldomArray* array_struct = (NaldomArray*)malloc(sizeof(NaldomArray));
+    if (!array_struct) return NULL;
+
+    // Allocate memory for the actual double values
+    array_struct->data = (double*)malloc(size * sizeof(double));
+    if (!array_struct->data) {
+        free(array_struct);
+        return NULL;
+    }
+    array_struct->size = size;
+
+    // Fill the array with random doubles between 0.0 and 100.0
+    for (int i = 0; i < size; ++i) {
+        array_struct->data[i] = (double)rand() / RAND_MAX * 100.0;
+    }
+
+    return array_struct;
+}
+
+// A comparison function for qsort
+int compare_doubles_asc(const void* a, const void* b) {
+    double val1 = *(const double*)a;
+    double val2 = *(const double*)b;
+    if (val1 < val2) return -1;
+    if (val1 > val2) return 1;
+    return 0;
+}
+
+int compare_doubles_desc(const void* a, const void* b) {
+    return compare_doubles_asc(b, a); // Reverse order
+}
+
+void sort_array(NaldomArray* arr, int64_t order) {
+    if (!arr || !arr->data) return;
+    printf("Runtime: Sorting the array...\n");
+    
+    if (order == 1) { // 1 for descending
+         qsort(arr->data, arr->size, sizeof(double), compare_doubles_desc);
+    } else { // 0 for ascending
+         qsort(arr->data, arr->size, sizeof(double), compare_doubles_asc);
+    }
+}
+
+void print_array(NaldomArray* arr) {
+    if (!arr || !arr->data) return;
+    
+    printf("\n--- Naldom Native Output ---\n[");
+    for (int i = 0; i < arr->size; ++i) {
+        printf("%.2f%s", arr->data[i], (i == arr->size - 1) ? "" : ", ");
+    }
+    printf("]\n--------------------------\n\n");
+}


### PR DESCRIPTION
Closes #7

This PR introduces the native C runtime and fixes critical issues in the LLVM codegen to ensure correct function signatures are generated, especially for pointers.

### Key Changes
- A new C file `runtime/native/naldom_runtime.c` now provides implementations for our standard library functions.
- The `codegen_llvm.rs` module was updated to correctly infer and declare function signatures for pointers and to use the modern `inkwell` API, resolving all previous compilation errors.

### How to Test
1. Run `cargo run --package naldom-cli -- program.md --emit=llvm-ir`.
2. Verify that the `declare` statements for `sort_array` and `print_array` now use a pointer type (`ptr`).
3. The C code itself will be tested in the next step when we implement the native build orchestration.

---
#### Pull Request Checklist
- [x] I have read the `CONTRIBUTING.md` document.
- [x] My code follows the project's coding style guidelines (`cargo fmt`).
- [ ] I have added/updated tests for my changes. *(N/A for this step)*
- [x] All existing tests pass.
- [x] My commit message follows the Conventional Commits specification.