### PR TITLE
feat(testing): Create end-to-end testing framework

### DIFF
--- a/crates/naldom-cli/Cargo.toml
+++ b/crates/naldom-cli/Cargo.toml
@@ -9,3 +9,9 @@ description = "Command-line interface (CLI) for the Naldom language."
 naldom-core = { path = "../naldom-core" }
 clap = { version = "4.5.4", features = ["derive"] }
 inkwell = { version = "0.6.0", default-features = false, features = ["llvm17-0", "target-x86", "target-webassembly"] }
+
+# Dependencies used only for running tests and benchmarks.
+[dev-dependencies]
+assert_cmd = "2.0"  # For testing command-line applications
+assert_fs = "1.0"   # For filesystem fixtures and assertions
+predicates = "3.0"  # For writing expressive assertions

--- a/tests/e2e/e2e_compiler_tests.rs
+++ b/tests/e2e/e2e_compiler_tests.rs
@@ -1,0 +1,34 @@
+// tests/e2e_compiler_tests.rs
+
+use assert_cmd::Command;
+use assert_fs::prelude::*;
+use predicates::prelude::*;
+use std::error::Error;
+
+#[test]
+fn test_compile_and_run_simple_program_native() -> Result<(), Box<dyn Error>> {
+    let temp = assert_fs::TempDir::new()?;
+    let input_file = temp.child("program.md");
+    input_file.write_str(
+        r#":::naldom
+Create an array of 5 random numbers.
+Sort it in ascending order.
+Print the result.
+:::"#,
+    )?;
+    let output_executable = temp.child("my_program");
+
+    let mut cmd = Command::cargo_bin("naldom-cli")?;
+    cmd.arg(input_file.path())
+        .arg("-o")
+        .arg(output_executable.path());
+    cmd.assert().success();
+
+    let mut run_cmd = Command::new(output_executable.path());
+    run_cmd
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--- Naldom Native Output ---"));
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #19 

This PR implements an automated end-to-end (E2E) testing framework, replacing the need for manual compilation and execution checks.

### Key Changes
- Added `assert_cmd`, `assert_fs`, and `predicates` as dev-dependencies to the `naldom-cli` crate, where integration tests are defined.
- Created a new integration test, `tests/e2e_compiler_tests.rs`, that verifies the full native compilation pipeline from a `.md` file to a running executable, checking its output.
- The `tests/` directory has been structured to accommodate different types of tests in the future.

### How to Test
- Run `cargo test --all-targets`. The new E2E test should be discovered and executed.
- **Note:** The `llama.cpp` server must be running for the E2E test to pass.

This provides a crucial safety net for ensuring the stability and correctness of the compiler as we add new features.

---
#### Pull Request Checklist
- [x] I have read the `CONTRIBUTING.md` document.
- [x] My code follows the project's coding style guidelines (`cargo fmt`).
- [x] I have added/updated tests for my changes.
- [x] All existing tests pass.
- [x] My commit message follows the Conventional Commits specification.